### PR TITLE
Allow Satis to keep a number of files that would otherwise be pruned

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,6 +38,7 @@ title: Config
   "require-dependencies": true,
   "require-dev-dependencies": true,
   "providers": false,
+  "providers-history-size": 0,
   "output-dir": "output",
   "output-html": true,
   "twig-template": "views/index.html.twig",

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -125,6 +125,10 @@
             "type": "boolean",
             "description": "If true, dump package providers."
         },
+        "providers-history-size": {
+            "type": "integer",
+            "description": "Optional integer to be used for keeping a number of files that would otherwise be pruned."
+        },
         "twig-template": {
             "type": "string",
             "description": "Path to a template for the static web page."


### PR DESCRIPTION
When working with an environment with many changes, a large set of
repositories and/or slow connections from clients that call
packages.json Satis could generate new files for packages whilst clients
were still downloading files from an older version of packages.json.
This caused HTTP 404 Not Found issues because old JSON files were already
pruned. This is occurred in environments with `providers` on `true`.

This change adds a new configuration `providers-history-size` which will
keep a number equal to the setting of old provider-specific JSON's to
remain stored.